### PR TITLE
Update veracode_delete_sandbox.py

### DIFF
--- a/veracode_delete_sandbox.py
+++ b/veracode_delete_sandbox.py
@@ -15,39 +15,63 @@ def main():
 
     parser = argparse.ArgumentParser(
         description='This script deletes a Sandbox if you have appropriate permissions - Note: this is not undoable')
-    parser.add_argument('-a', '--app', help='App name to delete sandbox in',required=True)
-    parser.add_argument('-s', '--sandbox', default="", help='Sandbox name to delete',required=True)
-    args = parser.parse_args()
+    parser.add_argument('-a', '--app', help='App name to delete sandbox in',required=False)
+    parser.add_argument('-s', '--sandbox', default="", help='Sandbox name to delete',required=False)
+    parser.add_argument('-y', '--year', default="", help='year',required=False)
+    parser.add_argument('-m', '--month', default="", help='month',required=False)
+    parser.add_argument('-d', '--day', default="", help='day',required=False)
 
+    args = parser.parse_args()
     data = VeracodeAPI().get_app_list()
     results = etree.fromstring(data)
     found = False
     for app in results:
-        if (app.attrib["app_name"] == args.app) and (args.sandbox != ""):
+        print ("app: " + app.attrib["app_name"])
+        if (app.attrib["app_name"] == args.app):
            sandbox_list=VeracodeAPI().get_sandbox_list(app.attrib["app_id"])
            sandboxes = etree.fromstring(sandbox_list)
+           print('sandbox: ' + args.sandbox)
+           print('year: ' + args.year)
            for sandbox in sandboxes:
-              if sandbox.attrib["sandbox_name"] == args.sandbox:
+              print ('Sandbox: ' + sandbox.attrib["sandbox_name"] + ', date: '  + sandbox.attrib["last_modified"])
+              lastModifiedDate = dt.datetime.strptime(sandbox.attrib["last_modified"], '%Y-%m-%dT%H:%M:%S%z')
+              if args.sandbox != '' and sandbox.attrib["sandbox_name"] == args.sandbox:
+                 print('found sandbox name ' + args.sandbox)
                  found = True
-                 try:
-                    response = requests.get(api_target, auth=RequestsAuthPluginVeracodeHMAC(), headers={"User-Agent": "api.py"},params={'sandbox_id': sandbox.attrib["sandbox_id"]})
-                 except requests.RequestException as e:
-                    print("Error occured")
-                    print(e)
-                    sys.exit(1)
-
-                 if response.ok:
-                    print("Sandbox deleted")
-                    exit(0)
-                 else:
-                    print(response.status_code)                 
-                    exit(1)
+                 remove_sandbox(sandbox)
+              elif args.year != '' and lastModifiedDate.year == int(args.year):
+                  print('found year ' + args.year)
+                  deletefile = True
+                  if args.month != '' and lastModifiedDate.month != int(args.month):
+                     print('month did not match')
+                     deletefile = False
+                  if args.day != '' and lastModifiedDate.day != int(args.day):
+                     print('day did not match')
+                     deletefile = False
+                  if deletefile == True:
+                   found = True
+                   remove_sandbox(sandbox)
               else:
                  print ('Sandbox: '+args.sandbox+' of app: '+args.app+' not found!')
                  exit(1)
     if (not found):
        print ('App: '+args.app+' with sandbox: '+args.sandbox+' does not exist')
     exit(1)
+
+def remove_sandbox(sandbox):
+   try:
+      response = requests.get(api_target, verify=False, auth=RequestsAuthPluginVeracodeHMAC(), headers={"User-Agent": "api.py"},params={'sandbox_id': sandbox.attrib["sandbox_id"]})
+   except requests.RequestException as e:
+      print("Error occurred")
+      print(e)
+      sys.exit(1)
+
+   if response.ok:
+      print("Sandbox deleted " + sandbox.attrib["sandbox_name"])
+   #   exit(0)
+   else:
+      print(response.status_code)                 
+      exit(1)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Added extra functionality to bulk delete sandboxes, now you can enter year/month/day and the app will remove all the files that match the criteria.
Now the app list the names of the veracode applications, incase you are not sure about the name, it will print at the end of the run
You can run:
- only with year
- only with year and month
- or if you want to be specific you can include year, month, day